### PR TITLE
feat(metronome): practice detail display upgrade (Phase A)

### DIFF
--- a/foxgita/Features/Practice/MetronomeDisplayCard.swift
+++ b/foxgita/Features/Practice/MetronomeDisplayCard.swift
@@ -14,8 +14,8 @@ struct MetronomeDisplayCard: View {
         return trimmed.isEmpty ? "4/4" : trimmed
     }
 
-    private var highlightedBeat: Int {
-        metronome.isPlaying ? metronome.currentBeatInBar : 0
+    private var activeBeat: Int? {
+        metronome.isPlaying ? metronome.currentBeatInBar : nil
     }
 
     var body: some View {
@@ -82,12 +82,12 @@ struct MetronomeDisplayCard: View {
             }
         }
         .frame(height: 58)
-        .animation(.easeInOut(duration: 0.12), value: highlightedBeat)
+        .animation(.easeInOut(duration: 0.12), value: activeBeat)
         .animation(.easeInOut(duration: 0.12), value: metronome.isPlaying)
     }
 
     private func beatBar(index: Int) -> some View {
-        let isActive = index == highlightedBeat
+        let isActive = activeBeat == index
         let fill = barFill(for: index, isActive: isActive)
         return RoundedRectangle(cornerRadius: GitaTheme.radius8)
             .fill(GitaTheme.brand50)
@@ -109,11 +109,12 @@ struct MetronomeDisplayCard: View {
     private var beatTrack: some View {
         HStack(spacing: 0) {
             ForEach(0..<4, id: \.self) { index in
+                let emphasized = trackDotEmphasized(index: index)
                 Circle()
-                    .fill(index == highlightedBeat ? GitaTheme.brand500 : GitaTheme.borderInactive)
+                    .fill(emphasized ? GitaTheme.brand500 : GitaTheme.borderInactive)
                     .frame(
-                        width: index == highlightedBeat ? 8 : 6,
-                        height: index == highlightedBeat ? 8 : 6
+                        width: emphasized ? 8 : 6,
+                        height: emphasized ? 8 : 6
                     )
                     .frame(maxWidth: .infinity)
             }
@@ -122,7 +123,12 @@ struct MetronomeDisplayCard: View {
         .padding(.horizontal, GitaTheme.s8)
         .background(GitaTheme.bgSubtle)
         .clipShape(Capsule())
-        .animation(.easeInOut(duration: 0.12), value: highlightedBeat)
+        .animation(.easeInOut(duration: 0.12), value: activeBeat)
+    }
+
+    private func trackDotEmphasized(index: Int) -> Bool {
+        if let activeBeat { return index == activeBeat }
+        return index == 0
     }
 
     private func metricLabel(_ text: String) -> some View {

--- a/foxgita/Features/Practice/MetronomeDisplayCard.swift
+++ b/foxgita/Features/Practice/MetronomeDisplayCard.swift
@@ -1,0 +1,153 @@
+//
+//  MetronomeDisplayCard.swift
+//  foxgita
+//
+
+import SwiftUI
+
+struct MetronomeDisplayCard: View {
+    let metronome: MetronomeEngine
+    let timeSignature: String
+
+    private var meterText: String {
+        let trimmed = timeSignature.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "4/4" : trimmed
+    }
+
+    private var highlightedBeat: Int {
+        metronome.isPlaying ? metronome.currentBeatInBar : 0
+    }
+
+    var body: some View {
+        VStack(spacing: GitaTheme.s12) {
+            labelRow
+            valueRow
+            beatBars
+            beatTrack
+        }
+        .padding(.horizontal, GitaTheme.s12)
+        .padding(.vertical, 10)
+        .background(GitaTheme.bgSurface)
+        .clipShape(RoundedRectangle(cornerRadius: GitaTheme.radius20))
+        .shadow(color: GitaTheme.shadowCard, radius: 8, y: 4)
+        .allowsHitTesting(false)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilitySummary)
+    }
+
+    private var labelRow: some View {
+        HStack(spacing: 0) {
+            metricLabel(String(localized: "速度 (BPM)"))
+                .frame(maxWidth: .infinity, alignment: .leading)
+            metricLabel(String(localized: "拍号"))
+                .frame(width: 76)
+            metricLabel(String(localized: "切分"))
+                .frame(width: 76, alignment: .trailing)
+        }
+    }
+
+    private var valueRow: some View {
+        HStack(spacing: 0) {
+            HStack(spacing: 6) {
+                Image(systemName: "music.note")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(GitaTheme.brand500)
+                Text("\(metronome.bpm)")
+                    .font(GitaFont.timer(.semibold))
+                    .foregroundStyle(GitaTheme.brand500)
+                Text(MetronomeTempoName.name(for: metronome.bpm))
+                    .font(GitaFont.micro())
+                    .foregroundStyle(GitaTheme.textSecondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Text(meterText)
+                .font(GitaFont.timer(.semibold))
+                .foregroundStyle(GitaTheme.brand500)
+                .frame(width: 76)
+
+            Image(systemName: "music.note")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(GitaTheme.brand500)
+                .frame(width: 76)
+        }
+    }
+
+    private var beatBars: some View {
+        HStack(spacing: GitaTheme.s8) {
+            ForEach(0..<4, id: \.self) { index in
+                beatBar(index: index)
+            }
+        }
+        .frame(height: 58)
+        .animation(.easeInOut(duration: 0.12), value: highlightedBeat)
+        .animation(.easeInOut(duration: 0.12), value: metronome.isPlaying)
+    }
+
+    private func beatBar(index: Int) -> some View {
+        let isActive = index == highlightedBeat
+        let fill = barFill(for: index, isActive: isActive)
+        return RoundedRectangle(cornerRadius: GitaTheme.radius8)
+            .fill(GitaTheme.brand50)
+            .overlay(alignment: .bottom) {
+                RoundedRectangle(cornerRadius: GitaTheme.radius8)
+                    .fill(isActive ? GitaTheme.brand500 : GitaTheme.brand50.opacity(0.85))
+                    .frame(height: 58 * fill)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: GitaTheme.radius8))
+            .accessibilityHidden(true)
+    }
+
+    private func barFill(for index: Int, isActive: Bool) -> CGFloat {
+        if isActive { return 0.72 }
+        if !metronome.isPlaying && index == 0 { return 0.18 }
+        return 0.12
+    }
+
+    private var beatTrack: some View {
+        HStack(spacing: 0) {
+            ForEach(0..<4, id: \.self) { index in
+                Circle()
+                    .fill(index == highlightedBeat ? GitaTheme.brand500 : GitaTheme.borderInactive)
+                    .frame(
+                        width: index == highlightedBeat ? 8 : 6,
+                        height: index == highlightedBeat ? 8 : 6
+                    )
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, GitaTheme.s8)
+        .background(GitaTheme.bgSubtle)
+        .clipShape(Capsule())
+        .animation(.easeInOut(duration: 0.12), value: highlightedBeat)
+    }
+
+    private func metricLabel(_ text: String) -> some View {
+        Text(text)
+            .font(GitaFont.micro())
+            .foregroundStyle(GitaTheme.textSecondary)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 4)
+            .background(GitaTheme.bgSubtle)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private var accessibilitySummary: String {
+        String(
+            localized: "节拍器，\(metronome.bpm) BPM，\(meterText) 拍，四分音符",
+            comment: "Metronome display card accessibility label"
+        )
+    }
+}
+
+#Preview {
+    MetronomeDisplayCard(
+        metronome: MetronomeEngine(),
+        timeSignature: "4/4"
+    )
+    .padding()
+    .background(GitaTheme.bgDefault)
+}

--- a/foxgita/Features/Practice/PracticeDetailView.swift
+++ b/foxgita/Features/Practice/PracticeDetailView.swift
@@ -355,22 +355,9 @@ struct PracticeDetailView: View {
                 VStack(alignment: .leading, spacing: 14) {
                     if !item.subtitle.isEmpty,
                        !AIPracticePresentation.isAIGenerated(subtitle: item.subtitle) {
-                        HStack {
-                            Text(item.subtitle)
-                            Spacer()
-                            if let timeSig = item.timeSignature, !timeSig.isEmpty {
-                                Text(timeSig)
-                            }
-                        }
-                        .font(.system(size: 12))
-                        .foregroundStyle(GitaTheme.textSecondary)
-                    } else if let timeSig = item.timeSignature, !timeSig.isEmpty {
-                        HStack {
-                            Spacer()
-                            Text(timeSig)
-                        }
-                        .font(.system(size: 12))
-                        .foregroundStyle(GitaTheme.textSecondary)
+                        Text(item.subtitle)
+                            .font(.system(size: 12))
+                            .foregroundStyle(GitaTheme.textSecondary)
                     }
 
                     if let resume = storedResumeState,
@@ -381,7 +368,10 @@ struct PracticeDetailView: View {
                             .accessibilityLabel(Text(line))
                     }
 
-                    metronomeCard
+                    MetronomeDisplayCard(
+                        metronome: metronome,
+                        timeSignature: item.timeSignature ?? "4/4"
+                    )
                     timerCard
                     if mode == .editable || !steps.isEmpty {
                         stepsCard
@@ -457,42 +447,6 @@ struct PracticeDetailView: View {
                 }
             )
         }
-    }
-
-    private var metronomeCard: some View {
-        VStack(spacing: 14) {
-            HStack {
-                Text("节拍器").font(GitaFont.headline())
-                Spacer()
-                Text("木质短音")
-                    .font(GitaFont.caption())
-                    .foregroundStyle(GitaTheme.textSecondary)
-            }
-            HStack {
-                circleBtn("－", label: String(localized: "降低 1 BPM")) {
-                    noteFocused = false
-                    metronome.bump(-1)
-                }
-                VStack(spacing: 0) {
-                    Text("\(metronome.bpm)")
-                        .font(GitaFont.timer())
-                    Text("BPM")
-                        .font(GitaFont.caption())
-                        .foregroundStyle(GitaTheme.textSecondary)
-                }
-                .frame(maxWidth: .infinity)
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel(Text("当前速度 \(metronome.bpm) BPM"))
-                circleBtn("＋", label: String(localized: "提高 1 BPM"), accent: true) {
-                    noteFocused = false
-                    metronome.bump(1)
-                }
-            }
-        }
-        .padding(18)
-        .background(GitaTheme.bgSurface)
-        .clipShape(RoundedRectangle(cornerRadius: 20))
-        .shadow(color: GitaTheme.shadowCard, radius: 8, y: 4)
     }
 
     private var timerCard: some View {
@@ -895,21 +849,6 @@ struct PracticeDetailView: View {
         let pattern: [CGFloat] = [8, 14, 20, 12, 22, 10, 18, 14]
         let base = pattern[index % pattern.count]
         return recorder.isPaused ? max(6, base * 0.45) : base
-    }
-
-    private func circleBtn(
-        _ title: String, label: String, accent: Bool = false, action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
-            Text(title)
-                .font(.system(size: 20, weight: .bold))
-                .foregroundStyle(accent ? GitaTheme.brand500 : GitaTheme.textSecondary)
-                .frame(minWidth: 48, minHeight: 48)
-                .background(accent ? GitaTheme.brand50 : GitaTheme.bgSubtle)
-                .clipShape(Circle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(Text(label))
     }
 
     private func tool(

--- a/foxgita/Services/MetronomeEngine.swift
+++ b/foxgita/Services/MetronomeEngine.swift
@@ -20,6 +20,7 @@ private let metronomeLog = Logger(subsystem: "com.haizei.foxgita", category: "me
 final class MetronomeEngine {
     private(set) var isPlaying = false
     private(set) var bpm = 80
+    private(set) var currentBeatInBar = 0
 
     private static let lead = 0.15
     private static let pumpInterval = 0.05
@@ -68,6 +69,7 @@ final class MetronomeEngine {
             guard engine.isRunning else { throw MetronomeError.engineNotRunning }
             player.stop()
             beatIndex = 0
+            currentBeatInBar = 0
             runToken += 1
             player.play()
             nextBeatFrame = currentFrame() + frames(0.1)
@@ -97,6 +99,7 @@ final class MetronomeEngine {
         player.stop()
         isPlaying = false
         beatIndex = 0
+        currentBeatInBar = 0
         runToken += 1
         session.release(.playback)
         metronomeLog.debug(
@@ -123,10 +126,12 @@ final class MetronomeEngine {
         if nextBeatFrame < now {
             nextBeatFrame = now + frames(0.05)
             beatIndex = 0
+            currentBeatInBar = 0
         }
         let horizon = now + frames(Self.lead)
         let step = frames(60.0 / Double(bpm))
         while nextBeatFrame <= horizon {
+            currentBeatInBar = beatIndex % 4
             let isDownbeat = beatIndex % 4 == 0
             player.scheduleBuffer(
                 isDownbeat ? accent : beat,

--- a/foxgita/Services/MetronomeTempoName.swift
+++ b/foxgita/Services/MetronomeTempoName.swift
@@ -1,0 +1,21 @@
+//
+//  MetronomeTempoName.swift
+//  foxgita
+//
+
+import Foundation
+
+enum MetronomeTempoName {
+    static func name(for bpm: Int) -> String {
+        let clamped = min(200, max(40, bpm))
+        switch clamped {
+        case 40...59: return "Largo"
+        case 60...75: return "Adagio"
+        case 76...87: return "Andantino"
+        case 88...107: return "Moderato"
+        case 108...119: return "Allegretto"
+        case 120...139: return "Allegro"
+        default: return "Presto"
+        }
+    }
+}

--- a/foxgitaTests/MetronomeEngineTests.swift
+++ b/foxgitaTests/MetronomeEngineTests.swift
@@ -60,4 +60,24 @@ struct MetronomeEngineTests {
         #expect(!metronome.isPlaying)
         #expect(!metronome.hasPump)
     }
+
+    @Test func currentBeatInBarStartsAtZero() {
+        let metronome = MetronomeEngine(session: AudioSessionCoordinator(apply: { }))
+        #expect(metronome.currentBeatInBar == 0)
+    }
+
+    @Test func stopResetsCurrentBeatInBar() throws {
+        let metronome = MetronomeEngine()
+        try metronome.start()
+        metronome.stop()
+        #expect(metronome.currentBeatInBar == 0)
+    }
+
+    @Test func startResetsCurrentBeatInBar() throws {
+        let metronome = MetronomeEngine()
+        try metronome.start()
+        metronome.stop()
+        try metronome.start()
+        #expect(metronome.currentBeatInBar == 0)
+    }
 }

--- a/foxgitaTests/MetronomeTempoNameTests.swift
+++ b/foxgitaTests/MetronomeTempoNameTests.swift
@@ -1,0 +1,23 @@
+import Testing
+@testable import foxgita
+
+struct MetronomeTempoNameTests {
+    @Test func mapsCommonTempos() {
+        #expect(MetronomeTempoName.name(for: 80) == "Andantino")
+        #expect(MetronomeTempoName.name(for: 76) == "Andantino")
+        #expect(MetronomeTempoName.name(for: 120) == "Allegro")
+        #expect(MetronomeTempoName.name(for: 60) == "Adagio")
+    }
+
+    @Test func clampsBeforeLookup() {
+        #expect(MetronomeTempoName.name(for: 10) == "Largo")
+        #expect(MetronomeTempoName.name(for: 250) == "Presto")
+    }
+
+    @Test func boundaryTransitions() {
+        #expect(MetronomeTempoName.name(for: 59) == "Largo")
+        #expect(MetronomeTempoName.name(for: 75) == "Adagio")
+        #expect(MetronomeTempoName.name(for: 87) == "Andantino")
+        #expect(MetronomeTempoName.name(for: 107) == "Moderato")
+    }
+}


### PR DESCRIPTION
## Summary

- Replace the legacy metronome card on practice detail with a three-column display: tempo name + BPM, time signature, and subdivision placeholder
- Add beat bar visualization synced to `MetronomeEngine.currentBeatInBar`; idle state uses subtle styling (no false active beat)
- Remove inline ± BPM controls from the card (settings sheet follows in #2)

## Test plan

- [ ] Practice detail shows new metronome display with tempo name, BPM, time signature, beat bars, and dot track
- [ ] Start/stop metronome → beat bars highlight in sync; idle shows no active beat highlight
- [ ] Meta row no longer duplicates time signature next to BPM
- [x] `MetronomeEngineTests` + `MetronomeTempoNameTests` pass


Made with [Cursor](https://cursor.com)